### PR TITLE
fix: add IgnorePointer to fix close button touch issue when image exp…

### DIFF
--- a/lib/src/sliders/image_slider_type_1_widget.dart
+++ b/lib/src/sliders/image_slider_type_1_widget.dart
@@ -202,10 +202,13 @@ class _ImageSliderType1State extends State<ImageSliderType1Widget> {
         ),
         ValueListenableBuilder<bool>(
           valueListenable: _isExpandSlide,
-          builder: (context, isExpand, child) => AnimatedOpacity(
-            opacity: (!isExpand) ? 1 : 0,
-            duration: widget.sliderDuration,
-            child: child,
+          builder: (context, isExpand, child) => IgnorePointer(
+            ignoring: isExpand,
+            child: AnimatedOpacity(
+              opacity: (!isExpand) ? 1 : 0,
+              duration: widget.sliderDuration,
+              child: child,
+            ),
           ),
           child: Column(
             children: [


### PR DESCRIPTION
## Problem
When an image is expanded, the close button (← icon with white opacity background) doesn't respond to touches properly. Only the very bottom area of the button is clickable.

## Cause
In the `Stack`, the slider `Column` is positioned above the expanded image. `AnimatedOpacity` only changes opacity to 0, but the widget **still receives touch events**, intercepting touches meant for the close button.

## Solution
Wrapped `AnimatedOpacity` with `IgnorePointer` to ignore touch events when expanded.

```dart
// Before
builder: (context, isExpand, child) => AnimatedOpacity(
  opacity: (!isExpand) ? 1 : 0,
  duration: widget.sliderDuration,
  child: child,
),

// After
builder: (context, isExpand, child) => IgnorePointer(
  ignoring: isExpand,
  child: AnimatedOpacity(
    opacity: (!isExpand) ? 1 : 0,
    duration: widget.sliderDuration,
    child: child,
  ),
),